### PR TITLE
Removes  º character that is causing bug

### DIFF
--- a/src/Base.svelte
+++ b/src/Base.svelte
@@ -222,7 +222,7 @@ let colorSquareEvent;
 let alphaPicker;
 let alphaEvent;
 let huePicker;
-let hueEvent;º
+let hueEvent;
 let colorSquare;
 
 const dispatch = createEventDispatcher();


### PR DESCRIPTION
 º is not defined
    at eval (/@fs/Users/scotttolinski/Sites/Level-Up-Tutorials/node_modules/.pnpm/svelte-picker@0.1.0/node_modules/svelte-picker/src/Base.svelte:85:2)
    at Object.$$render (/Users/scotttolinski/Sites/Level-Up-Tutorials/node_modules/.pnpm/svelte@3.45.0/node_modules/svelte`